### PR TITLE
Item creation and editing

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -16,6 +16,7 @@ class ItemsController < ApplicationController
       merchant_id: params[:merchant_id]
     )
     item.save
+    flash[:success] = "Item information updated successfully."
 
     redirect_to "/items/#{item.id}"
   end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,0 +1,22 @@
+class ItemsController < ApplicationController
+  def show
+    @item = Item.find(params[:id])
+  end
+  
+  def edit
+    @item = Item.find(params[:id])
+  end
+
+  def update
+    item = Item.find(params[:id])
+    item.update(
+      name: params[:name],
+      description: params[:description],
+      unit_price: params[:unit_price],
+      merchant_id: params[:merchant_id]
+    )
+    item.save
+
+    redirect_to "/items/#{item.id}"
+  end
+end

--- a/app/controllers/merchant_items_controller.rb
+++ b/app/controllers/merchant_items_controller.rb
@@ -15,4 +15,20 @@ class MerchantItemsController < ApplicationController
 
     redirect_to "/merchants/#{params[:merchant_id]}/items"
   end
+
+  def new
+    @merchant = Merchant.find(params[:merchant_id])
+  end
+
+  def create
+    Item.create(
+      name: params[:name],
+      description: params[:description],
+      unit_price: params[:unit_price],
+      merchant_id: params[:merchant_id],
+      status: 0
+    )
+
+    redirect_to "/merchants/#{params[:merchant_id]}/items"
+  end
 end

--- a/app/controllers/merchant_items_controller.rb
+++ b/app/controllers/merchant_items_controller.rb
@@ -6,4 +6,13 @@ class MerchantItemsController < ApplicationController
   def show
     @item = Item.find(params[:item_id])
   end
+
+  def update
+    item = Item.find(params[:item_id])
+
+    item.update(status: (params[:status] == "enable" ? 1 : 0))
+    item.save
+
+    redirect_to "/merchants/#{params[:merchant_id]}/items"
+  end
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -6,6 +6,8 @@ class Item < ApplicationRecord
   validates :description, presence: true
   validates :unit_price, presence: true
 
+  enum status: { 'disabled' => 0, 'enabled' => 1 }
+
   def unit_price_formatted
     unit_price.to_f / 100
   end

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -1,0 +1,13 @@
+<h1>Update <%= @item.name %></h1>
+
+<%= form_with url: "/items/#{@item.id}", method: :patch, data: { turbo: false } do |form| %>
+  <%= form.label :name, "Name:" %>
+  <%= form.text_field :name, value: @item.name %><br>
+  <%= form.label :description, "Description:" %>
+  <%= form.text_field :description, value: @item.description %><br>
+  <%= form.label :unit_price, "Unit Price:" %>
+  <%= form.text_field :unit_price, value: @item.unit_price %><br>
+  <%= form.label :merchant_id, "Merchant ID:" %>
+  <%= form.text_field :merchant_id, value: @item.merchant_id %><br>
+  <%= form.submit "Update Item" %>
+<% end %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -1,0 +1,8 @@
+<h1><%= @item.name %></h1>
+
+<ul>
+  <li>Name: <%= @item.name %></li>
+  <li>Description: <%= @item.description %></li>
+  <li>Unit Price: <%= @item.unit_price %></li>
+  <li>Merchant ID: <%= @item.merchant_id %></li>
+</ul>

--- a/app/views/merchant_items/index.html.erb
+++ b/app/views/merchant_items/index.html.erb
@@ -3,6 +3,13 @@
 <p>Available items:</p>
 <ul>
   <% @merchant.items.each do |item| %>
-    <li id="item-<%= item.id %>"><a href="/merchants/<%= @merchant.id%>/items/<%= item.id %>"><%= item.name %></a></li>
+    <li id="item-<%= item.id %>"><a href="/merchants/<%= @merchant.id%>/items/<%= item.id %>"><%= item.name %></a>
+    <% if item.status == nil || item.status == "enabled" %>
+      <%= button_to "Disable Item", "/merchants/#{@merchant.id}/items/#{item.id}", method: :patch, data: { turbo: false }, params: { status: "disable" } %>
+    <% else %>
+      <%= button_to "Enable Item", "/merchants/#{@merchant.id}/items/#{item.id}", method: :patch, data: { turbo: false }, params: { status: "enable" } %>
+    <% end %>
+    </li>
+    <br>
   <% end %>
 </ul>

--- a/app/views/merchant_items/index.html.erb
+++ b/app/views/merchant_items/index.html.erb
@@ -1,5 +1,7 @@
 <h1><%= @merchant.name %></h1>
 
+<p><%= link_to "Create an Item", "/merchants/#{@merchant.id}/items/new" %></p>
+
 <p>Enabled items:</p>
 <ul id="status-enabled">
   <% @merchant.items.each do |item| %>

--- a/app/views/merchant_items/index.html.erb
+++ b/app/views/merchant_items/index.html.erb
@@ -2,7 +2,7 @@
 
 <p><%= link_to "Create an Item", "/merchants/#{@merchant.id}/items/new" %></p>
 
-<p>Enabled items:</p>
+<h2>Enabled items:</h2>
 <ul id="status-enabled">
   <% @merchant.items.each do |item| %>
     <% if item.status == nil || item.status == "enabled" %>
@@ -13,8 +13,8 @@
     <% end %>
   <% end %>
 </ul>
-<br><br>
-<p>Disabled items:</p>
+<br>
+<h2>Disabled items:</h2>
 <ul id="status-disabled">
   <% @merchant.items.each do |item| %>
     <% if item.status == "disabled" %>

--- a/app/views/merchant_items/index.html.erb
+++ b/app/views/merchant_items/index.html.erb
@@ -1,15 +1,25 @@
 <h1><%= @merchant.name %></h1>
 
-<p>Available items:</p>
-<ul>
+<p>Enabled items:</p>
+<ul id="status-enabled">
   <% @merchant.items.each do |item| %>
-    <li id="item-<%= item.id %>"><a href="/merchants/<%= @merchant.id%>/items/<%= item.id %>"><%= item.name %></a>
     <% if item.status == nil || item.status == "enabled" %>
-      <%= button_to "Disable Item", "/merchants/#{@merchant.id}/items/#{item.id}", method: :patch, data: { turbo: false }, params: { status: "disable" } %>
-    <% else %>
-      <%= button_to "Enable Item", "/merchants/#{@merchant.id}/items/#{item.id}", method: :patch, data: { turbo: false }, params: { status: "enable" } %>
+      <li id="item-<%= item.id %>"><a href="/merchants/<%= @merchant.id%>/items/<%= item.id %>"><%= item.name %></a>
+        <%= button_to "Disable Item", "/merchants/#{@merchant.id}/items/#{item.id}", method: :patch, data: { turbo: false }, params: { status: "disable" } %>
+      </li>
+      <br>
     <% end %>
-    </li>
-    <br>
+  <% end %>
+</ul>
+<br><br>
+<p>Disabled items:</p>
+<ul id="status-disabled">
+  <% @merchant.items.each do |item| %>
+    <% if item.status == "disabled" %>
+      <li id="item-<%= item.id %>"><a href="/merchants/<%= @merchant.id%>/items/<%= item.id %>"><%= item.name %></a>
+        <%= button_to "Enable Item", "/merchants/#{@merchant.id}/items/#{item.id}", method: :patch, data: { turbo: false }, params: { status: "enable" } %>
+      </li>
+      <br>
+    <% end %>
   <% end %>
 </ul>

--- a/app/views/merchant_items/new.html.erb
+++ b/app/views/merchant_items/new.html.erb
@@ -1,0 +1,11 @@
+<h1>Create an Item for <%= @merchant.name %></h1>
+
+<%= form_with url: "/merchants/#{@merchant.id}/items/create", method: :post, data: { turbo: false } do |form| %>
+  <%= form.label :name, "Name:" %>
+  <%= form.text_field :name %><br>
+  <%= form.label :description, "Description:" %>
+  <%= form.text_field :description %><br>
+  <%= form.label :unit_price, "Unit price:" %>
+  <%= form.text_field :unit_price %><br>
+  <%= form.submit "Create Item" %>
+<% end %>

--- a/app/views/merchant_items/show.html.erb
+++ b/app/views/merchant_items/show.html.erb
@@ -5,3 +5,5 @@
   <li>Description: <%= @item.description %></li>
   <li>Unit price: <%= number_to_currency(@item.unit_price / 100.0) %></li>
 </ul>
+
+<%= link_to "Update Item", "/items/#{@item.id}/edit" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,7 @@ Rails.application.routes.draw do
   get "/merchants/:merchant_id/dashboard", to: "merchants#show"
   get "/merchants/:merchant_id/items", to: "merchant_items#index"
   get "/merchants/:merchant_id/items/:item_id", to: "merchant_items#show"
+  patch "/merchants/:merchant_id/items/:item_id", to: "merchant_items#update"
 
   get "/items/:id", to: "items#show"
   get "/items/:id/edit", to: "items#edit"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,8 @@ Rails.application.routes.draw do
   # root "articles#index"
   get "/merchants/:merchant_id/dashboard", to: "merchants#show"
   get "/merchants/:merchant_id/items", to: "merchant_items#index"
+  get "/merchants/:merchant_id/items/new", to: "merchant_items#new"
+  post "/merchants/:merchant_id/items/create", to: "merchant_items#create"
   get "/merchants/:merchant_id/items/:item_id", to: "merchant_items#show"
   patch "/merchants/:merchant_id/items/:item_id", to: "merchant_items#update"
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,10 @@ Rails.application.routes.draw do
   get "/merchants/:merchant_id/items", to: "merchant_items#index"
   get "/merchants/:merchant_id/items/:item_id", to: "merchant_items#show"
 
+  get "/items/:id", to: "items#show"
+  get "/items/:id/edit", to: "items#edit"
+  patch "/items/:id", to: "items#update"
+
 
   namespace :admin, path: '/admin' do
     get '', to: 'dashboard#index', as: 'dashboard'

--- a/db/migrate/20230918195641_add_status_to_items.rb
+++ b/db/migrate/20230918195641_add_status_to_items.rb
@@ -1,0 +1,5 @@
+class AddStatusToItems < ActiveRecord::Migration[7.0]
+  def change
+    add_column :items, :status, :integer, using: 'status::integer'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_09_15_224034) do
+ActiveRecord::Schema[7.0].define(version: 2023_09_18_195641) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -48,6 +48,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_15_224034) do
     t.bigint "merchant_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "status"
     t.index ["merchant_id"], name: "index_items_on_merchant_id"
   end
 

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -4,6 +4,7 @@ FactoryBot.define do
     description { Faker::Commerce.material }
     unit_price { Faker::Commerce.price(range: 0..10.0, as_string: true) }
     merchant_id { 1 }
+    status { 1 }
     created_at { "2023-09-11 16:40:54" }
     updated_at { "2023-09-11 16:40:54" }
   end

--- a/spec/features/items/edit_spec.rb
+++ b/spec/features/items/edit_spec.rb
@@ -1,0 +1,47 @@
+require 'rails_helper'
+
+RSpec.describe "Items Edit", type: :feature do
+  before(:each) do
+    @merchant_1 = create(:merchant)
+    @merchant_2 = create(:merchant)
+    @item_1 = create(:item, merchant_id: @merchant_1.id, unit_price: 1234)
+    @item_2 = create(:item, merchant_id: @merchant_1.id)
+    @item_3 = create(:item, merchant_id: @merchant_1.id)
+    @item_4 = create(:item, merchant_id: @merchant_1.id)
+    @item_5 = create(:item, merchant_id: @merchant_2.id)
+    @item_6 = create(:item, merchant_id: @merchant_2.id)
+    @item_7 = create(:item, merchant_id: @merchant_2.id)
+    @item_8 = create(:item, merchant_id: @merchant_2.id)
+    @item_9 = create(:item, merchant_id: @merchant_2.id)
+  end
+
+  describe "When I visit the items edit page" do
+    it "opens a form to edit the item" do
+      visit "/items/#{@item_1.id}/edit"
+
+      expect(page).to have_field("name")
+      expect(page).to have_field("description")
+      expect(page).to have_field("unit_price")
+      expect(page).to have_field("merchant_id")
+      expect(page).to have_button("Update Item")
+    end
+
+    it "updates the item and returns the user to the item show page when the form is submitted" do
+      visit "/items/#{@item_1.id}/edit"
+      
+      fill_in("name", with: "Updated Name")
+      fill_in("description", with: "Updated Description")
+      fill_in("unit_price", with: "10234")
+      fill_in("merchant_id", with: "2")
+      click_button("Update Item")
+
+      expect(page).to have_current_path("/items/#{@item_1.id}")
+
+      expect(page).to have_content("Name: Updated Name")
+      expect(page).to have_content("Description: Updated Description")
+      expect(page).to have_content("Unit Price: 10234")
+      expect(page).to have_content("Merchant ID: 2")
+      expect(page).to have_content("Item was successfully updated!")
+    end
+  end
+end

--- a/spec/features/items/edit_spec.rb
+++ b/spec/features/items/edit_spec.rb
@@ -26,22 +26,22 @@ RSpec.describe "Items Edit", type: :feature do
       expect(page).to have_button("Update Item")
     end
 
-    xit "updates the item and returns the user to the item show page when the form is submitted" do #this works locally but the test is failing, will fix later
+    it "updates the item and returns the user to the item show page when the form is submitted" do
       visit "/items/#{@item_1.id}/edit"
       
       fill_in "name", with: "Updated Name"
       fill_in "description", with: "Updated Description"
       fill_in "unit_price", with: "10234"
-      fill_in "merchant_id", with: "2"
-      click_button("Update Item")
+      fill_in "merchant_id", with: "#{@merchant_2.id}"
+      click_button "Update Item"
 
       expect(page).to have_current_path("/items/#{@item_1.id}")
 
       expect(page).to have_content("Name: Updated Name")
       expect(page).to have_content("Description: Updated Description")
       expect(page).to have_content("Unit Price: 10234")
-      expect(page).to have_content("Merchant ID: 2")
-      expect(page).to have_content("Item was successfully updated!")
+      expect(page).to have_content("Merchant ID: #{@merchant_2.id}")
+      expect(page).to have_content("Item information updated successfully.")
     end
   end
 end

--- a/spec/features/items/edit_spec.rb
+++ b/spec/features/items/edit_spec.rb
@@ -26,13 +26,13 @@ RSpec.describe "Items Edit", type: :feature do
       expect(page).to have_button("Update Item")
     end
 
-    it "updates the item and returns the user to the item show page when the form is submitted" do
+    xit "updates the item and returns the user to the item show page when the form is submitted" do #this works locally but the test is failing, will fix later
       visit "/items/#{@item_1.id}/edit"
       
-      fill_in("name", with: "Updated Name")
-      fill_in("description", with: "Updated Description")
-      fill_in("unit_price", with: "10234")
-      fill_in("merchant_id", with: "2")
+      fill_in "name", with: "Updated Name"
+      fill_in "description", with: "Updated Description"
+      fill_in "unit_price", with: "10234"
+      fill_in "merchant_id", with: "2"
       click_button("Update Item")
 
       expect(page).to have_current_path("/items/#{@item_1.id}")

--- a/spec/features/items/show_spec.rb
+++ b/spec/features/items/show_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+RSpec.describe "Items Show", type: :feature do
+  before(:each) do
+    @merchant_1 = create(:merchant)
+    @merchant_2 = create(:merchant)
+    @item_1 = create(:item, merchant_id: @merchant_1.id, unit_price: 1234)
+    @item_2 = create(:item, merchant_id: @merchant_1.id)
+    @item_3 = create(:item, merchant_id: @merchant_2.id)
+    @item_4 = create(:item, merchant_id: @merchant_2.id)
+  end
+
+  describe "When I visit the items show page" do
+    it "I see all attributes of the item, including name, description, unit price and merchant id" do
+      visit "/items/#{@item_1.id}"
+
+      expect(page).to have_content(@item_1.name)
+      expect(page).to have_content(@item_1.description)
+      expect(page).to have_content(@item_1.unit_price)
+      expect(page).to have_content(@item_1.merchant_id)
+      expect(page).to_not have_content(@item_2.name)
+      expect(page).to_not have_content(@item_2.description)
+      expect(page).to_not have_content(@item_2.unit_price)
+      expect(page).to_not have_content(@item_2.merchant_id)
+    end
+  end
+end

--- a/spec/features/items/show_spec.rb
+++ b/spec/features/items/show_spec.rb
@@ -18,10 +18,8 @@ RSpec.describe "Items Show", type: :feature do
       expect(page).to have_content(@item_1.description)
       expect(page).to have_content(@item_1.unit_price)
       expect(page).to have_content(@item_1.merchant_id)
-      expect(page).to_not have_content(@item_2.name)
-      expect(page).to_not have_content(@item_2.description)
-      expect(page).to_not have_content(@item_2.unit_price)
-      expect(page).to_not have_content(@item_2.merchant_id)
+      expect(page).to_not have_content(@item_3.name)
+      expect(page).to_not have_content(@item_3.merchant_id)
     end
   end
 end

--- a/spec/features/merchant_items/index_spec.rb
+++ b/spec/features/merchant_items/index_spec.rb
@@ -40,5 +40,27 @@ RSpec.describe "MerchantItems Index", type: :feature do
 
       expect(page).to have_current_path("/merchants/#{@merchant_1.id}/items/#{@item_1.id}")
     end
+
+    it "each item has a button to enable or disable it, and clicking it performs that action" do
+      visit "/merchants/#{@merchant_1.id}/items"
+
+      within("#item-#{@item_1.id}") do
+        expect(page).to have_button("Disable Item")
+        click_button("Disable Item")
+      end
+
+      expect(page).to have_current_path("/merchants/#{@merchant_1.id}/items")
+
+      within("#item-#{@item_1.id}") do
+        expect(page).to have_button("Enable Item")
+        click_button("Enable Item")
+      end
+
+      expect(page).to have_current_path("/merchants/#{@merchant_1.id}/items")
+
+      within("#item-#{@item_1.id}") do
+        expect(page).to have_button("Disable Item")
+      end
+    end
   end
 end

--- a/spec/features/merchant_items/index_spec.rb
+++ b/spec/features/merchant_items/index_spec.rb
@@ -65,7 +65,6 @@ RSpec.describe "MerchantItems Index", type: :feature do
 
     it "items are split into two sections, one for enabled items and one for disabled items" do
       visit "/merchants/#{@merchant_1.id}/items"
-      save_and_open_page
 
       within("#status-enabled") do
         expect(page).to have_content(@item_1.name)

--- a/spec/features/merchant_items/index_spec.rb
+++ b/spec/features/merchant_items/index_spec.rb
@@ -65,6 +65,7 @@ RSpec.describe "MerchantItems Index", type: :feature do
 
     it "items are split into two sections, one for enabled items and one for disabled items" do
       visit "/merchants/#{@merchant_1.id}/items"
+      save_and_open_page
 
       within("#status-enabled") do
         expect(page).to have_content(@item_1.name)

--- a/spec/features/merchant_items/index_spec.rb
+++ b/spec/features/merchant_items/index_spec.rb
@@ -81,5 +81,11 @@ RSpec.describe "MerchantItems Index", type: :feature do
         expect(page).to have_content(@item_4.name)
       end
     end
+
+    it "has a link to create a new item" do
+      visit "/merchants/#{@merchant_1.id}/items"
+
+      expect(page).to have_link("Create an Item", href: "/merchants/#{@merchant_1.id}/items/new")
+    end
   end
 end

--- a/spec/features/merchant_items/index_spec.rb
+++ b/spec/features/merchant_items/index_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe "MerchantItems Index", type: :feature do
     @merchant_2 = create(:merchant)
     @item_1 = create(:item, merchant_id: @merchant_1.id)
     @item_2 = create(:item, merchant_id: @merchant_1.id)
-    @item_3 = create(:item, merchant_id: @merchant_1.id)
-    @item_4 = create(:item, merchant_id: @merchant_1.id)
+    @item_3 = create(:item, merchant_id: @merchant_1.id, status: 0)
+    @item_4 = create(:item, merchant_id: @merchant_1.id, status: 0)
     @item_5 = create(:item, merchant_id: @merchant_2.id)
     @item_6 = create(:item, merchant_id: @merchant_2.id)
     @item_7 = create(:item, merchant_id: @merchant_2.id)
@@ -60,6 +60,24 @@ RSpec.describe "MerchantItems Index", type: :feature do
 
       within("#item-#{@item_1.id}") do
         expect(page).to have_button("Disable Item")
+      end
+    end
+
+    it "items are split into two sections, one for enabled items and one for disabled items" do
+      visit "/merchants/#{@merchant_1.id}/items"
+
+      within("#status-enabled") do
+        expect(page).to have_content(@item_1.name)
+        expect(page).to have_content(@item_2.name)
+        expect(page).to_not have_content(@item_3.name)
+        expect(page).to_not have_content(@item_4.name)
+      end
+
+      within("#status-disabled") do
+        expect(page).to_not have_content(@item_1.name)
+        expect(page).to_not have_content(@item_2.name)
+        expect(page).to have_content(@item_3.name)
+        expect(page).to have_content(@item_4.name)
       end
     end
   end

--- a/spec/features/merchant_items/new_spec.rb
+++ b/spec/features/merchant_items/new_spec.rb
@@ -24,9 +24,7 @@ RSpec.describe "Merchant Items New", type: :feature do
       click_button("Create Item")
 
       expect(page).to have_current_path("/merchants/#{@merchant_1.id}/items")
-      expect(page).to have_content("Name: Test Item")
-      expect(page).to have_content("Description: Test Description")
-      expect(page).to have_content("Unit Price: 10234")
+      expect(page).to have_content("Test Item")
     end
 
     it "submitting the form creates the item with a default status of disabled" do

--- a/spec/features/merchant_items/new_spec.rb
+++ b/spec/features/merchant_items/new_spec.rb
@@ -1,0 +1,49 @@
+require 'rails_helper'
+
+RSpec.describe "Merchant Items New", type: :feature do
+  before(:each) do
+    @merchant_1 = create(:merchant)
+  end
+
+  describe "When I visit the merchant items new page" do
+    it "I see a form to create a new item" do
+      visit "/merchants/#{@merchant_1.id}/items/new"
+
+      expect(page).to have_field("name")
+      expect(page).to have_field("description")
+      expect(page).to have_field("unit_price")
+      expect(page).to have_button("Create Item")
+    end
+
+    it "submitting the form creates a new item and takes me to the merchant items index page" do
+      visit "/merchants/#{@merchant_1.id}/items/new"
+
+      fill_in("name", with: "Test Item")
+      fill_in("description", with: "Test Description")
+      fill_in("unit_price", with: 10234)
+      click_button("Create Item")
+
+      expect(page).to have_current_path("/merchants/#{@merchant_1.id}/items")
+      expect(page).to have_content("Name: Test Item")
+      expect(page).to have_content("Description: Test Description")
+      expect(page).to have_content("Unit Price: 10234")
+    end
+
+    it "submitting the form creates the item with a default status of disabled" do
+      visit "/merchants/#{@merchant_1.id}/items/new"
+
+      fill_in("name", with: "Test Item")
+      fill_in("description", with: "Test Description")
+      fill_in("unit_price", with: 10234)
+      click_button("Create Item")
+
+      within("#status-disabled") do
+        expect(page).to have_content("Test Item")
+      end
+
+      within("#status-enabled") do
+        expect(page).to_not have_content("Test Item")
+      end
+    end
+  end
+end

--- a/spec/features/merchant_items/show_spec.rb
+++ b/spec/features/merchant_items/show_spec.rb
@@ -24,16 +24,10 @@ RSpec.describe "MerchantItems Show", type: :feature do
       expect(page).to have_content("Unit price: $12.34")
     end
 
-    it "has a link for each item to update that item" do
+    it "has a link to update that item" do
       visit "/merchants/#{@merchant_1.id}/items/#{@item_1.id}"
       
-      within("#item-#{@item_1.id}") do
-        expect(page).to have_link("Update Item", href: "/items/#{@item_1.id}/edit")
-      end
-
-      within("#item-#{@item_2.id}") do
-        expect(page).to have_link("Update Item", href: "/items/#{@item_2.id}/edit")
-      end
+      expect(page).to have_link("Update Item", href: "/items/#{@item_1.id}/edit")
     end
   end
 end

--- a/spec/features/merchant_items/show_spec.rb
+++ b/spec/features/merchant_items/show_spec.rb
@@ -23,5 +23,17 @@ RSpec.describe "MerchantItems Show", type: :feature do
       expect(page).to have_content("Description: #{@item_1.description}")
       expect(page).to have_content("Unit price: $12.34")
     end
+
+    it "has a link for each item to update that item" do
+      visit "/merchants/#{@merchant_1.id}/items/#{@item_1.id}"
+      
+      within("#item-#{@item_1.id}") do
+        expect(page).to have_link("Update Item", href: "/items/#{@item_1.id}/edit")
+      end
+
+      within("#item-#{@item_2.id}") do
+        expect(page).to have_link("Update Item", href: "/items/#{@item_2.id}/edit")
+      end
+    end
   end
 end

--- a/spec/features/merchants/show_spec.rb
+++ b/spec/features/merchants/show_spec.rb
@@ -1,39 +1,40 @@
 require "rails_helper"
 
 RSpec.describe "merchant#show" do
+  before :each do
+    @merchant_1 = create(:merchant)
+    @customer_1 = create(:customer)
+    @customer_2 = create(:customer)
+    @customer_3 = create(:customer)
+    @customer_4 = create(:customer)
+    @customer_5 = create(:customer)
+    
+    @item_1 = create(:item, merchant_id: @merchant_1.id)
+    @item_2 = create(:item, merchant_id: @merchant_1.id)
+    @item_3 = create(:item, merchant_id: @merchant_1.id)
+    @item_4 = create(:item, merchant_id: @merchant_1.id)
+    @item_5 = create(:item, merchant_id: @merchant_1.id)
+
+    @invoice_1 = create(:invoice, customer_id: @customer_1.id)
+    @invoice_2 = create(:invoice, customer_id: @customer_2.id)
+    @invoice_3 = create(:invoice, customer_id: @customer_3.id)
+    @invoice_4 = create(:invoice, customer_id: @customer_4.id)
+    @invoice_5 = create(:invoice, customer_id: @customer_5.id)
+
+    @invoice_item_1 = create(:invoice_item, item_id: @item_1.id, invoice_id: @invoice_1.id, status: 2)
+    @invoice_item_2 = create(:invoice_item, item_id: @item_2.id, invoice_id: @invoice_2.id, status: 2)
+    @invoice_item_3 = create(:invoice_item, item_id: @item_3.id, invoice_id: @invoice_3.id, status: 2)
+    @invoice_item_4 = create(:invoice_item, item_id: @item_4.id, invoice_id: @invoice_4.id, status: 2)
+    @invoice_item_5 = create(:invoice_item, item_id: @item_5.id, invoice_id: @invoice_5.id, status: 2)
+
+    @transaction_1 = create(:transaction, invoice_id: @invoice_1.id, result: 0)
+    @transaction_2 = create(:transaction, invoice_id: @invoice_2.id, result: 0)
+    @transaction_3 = create(:transaction, invoice_id: @invoice_3.id, result: 0)
+    @transaction_4 = create(:transaction, invoice_id: @invoice_4.id, result: 0)
+    @transaction_5 = create(:transaction, invoice_id: @invoice_5.id, result: 0)
+  end
+  
   describe "display merchant info" do
-    before :each do
-      @merchant_1 = create(:merchant)
-      @customer_1 = create(:customer)
-      @customer_2 = create(:customer)
-      @customer_3 = create(:customer)
-      @customer_4 = create(:customer)
-      @customer_5 = create(:customer)
-      
-      @item_1 = create(:item, merchant_id: @merchant_1.id)
-      @item_2 = create(:item, merchant_id: @merchant_1.id)
-      @item_3 = create(:item, merchant_id: @merchant_1.id)
-      @item_4 = create(:item, merchant_id: @merchant_1.id)
-      @item_5 = create(:item, merchant_id: @merchant_1.id)
-
-      @invoice_1 = create(:invoice, customer_id: @customer_1.id)
-      @invoice_2 = create(:invoice, customer_id: @customer_2.id)
-      @invoice_3 = create(:invoice, customer_id: @customer_3.id)
-      @invoice_4 = create(:invoice, customer_id: @customer_4.id)
-      @invoice_5 = create(:invoice, customer_id: @customer_5.id)
-
-      @invoice_item_1 = create(:invoice_item, item_id: @item_1.id, invoice_id: @invoice_1.id, status: 2)
-      @invoice_item_2 = create(:invoice_item, item_id: @item_2.id, invoice_id: @invoice_2.id, status: 2)
-      @invoice_item_3 = create(:invoice_item, item_id: @item_3.id, invoice_id: @invoice_3.id, status: 2)
-      @invoice_item_4 = create(:invoice_item, item_id: @item_4.id, invoice_id: @invoice_4.id, status: 2)
-      @invoice_item_5 = create(:invoice_item, item_id: @item_5.id, invoice_id: @invoice_5.id, status: 2)
-
-      @transaction_1 = create(:transaction, invoice_id: @invoice_1.id, result: 0)
-      @transaction_2 = create(:transaction, invoice_id: @invoice_2.id, result: 0)
-      @transaction_3 = create(:transaction, invoice_id: @invoice_3.id, result: 0)
-      @transaction_4 = create(:transaction, invoice_id: @invoice_4.id, result: 0)
-      @transaction_5 = create(:transaction, invoice_id: @invoice_5.id, result: 0)
-    end
 
     it "has merchant info listed " do
       merchant_1 = create(:merchant)

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Item, type: :model do
 
   describe "ready_to_ship" do
     it "can display items with a status of 'packaged'" do
-      item = 
+      
     end
   end
 end


### PR DESCRIPTION
It's a doozy. This PR completes stories 8-11 since they were all similar/reliant functionality on each other.
!!! RUN `rails db:migrate` AFTER PULLING MAIN !!!

Database/Migrations:
- Adds a status enum column to items

Routes:
- show, edit, update for items
- new, create, update for merchant_items
- These are separate because in US 8 you are editing a specific item, hence item routing. In US 9/10/11, you are modifying/creating items as they related to the specific merchant, hence merchant_item routing. Ultimately these could be combined down into one controller, but in my head it made more sense this way when I did it!

Models:
- Add a status enum to the item model (disabled => 0, enabled => 1)

Controllers:
- Adds show, edit, update actions for the items_controller
- Adds new, create, update actions for the merchant_items_controller (see justification in Routes)

Views:
- Create views for items show and edit + merchant_items new
- Update views for merchant_items index and show

Testing:
- Full, passing test coverage for all views and controllers for stories 8-11
- DOES NOT ADD VALIDATION OF ENUM TO ITEM MODEL AS IM UNSURE HOW TO VALIDATE A COLUMN THAT MAY BE NIL

Features:
- Edit an existing item from the merchants item index page
- Add a new item from the merchants item index page
- Enable/Disable items from the merchants item index page
- Sort items by enabled/disabled on the merchants item index page

Considerations(Extra notes, refactors, etc.):
- Full test coverage, I also made very small modifications to some /merchants tests that were throwing a fit, but those aren't complete so I didn't complete any that weren't already working.
- Read final bullet of `Routes` for justification on the controller split. Honestly, it would be fine to just merge these and make no difference outside of needing some extra login in the update action. That being said, I feel my justifaction is valid. Please review!
- MIGRATE YOUR DATABASE AFTER THIS IS MERGED!!