### PR TITLE
Merchant popular items

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,6 +1,7 @@
 class Item < ApplicationRecord
   belongs_to :merchant
   has_many :invoice_items
+  has_many :invoices, through: :invoice_items
 
   validates :name, presence: true
   validates :description, presence: true
@@ -12,8 +13,14 @@ class Item < ApplicationRecord
     unit_price.to_f / 100
   end
 
-  
-
-  #don't love this method because I'm not certain it's doing what I want here
-  # Is this stuff on line 15 doing it as a SQL with the quotes? how can I write this to work with AR?
+  def best_day
+    Item
+    .joins(:invoices)
+    .where("items.id = ?", self.id)
+    .select("SUM(invoice_items.quantity) as items_sold, invoices.created_at::date as created_at")
+    .group("invoices.created_at::date")
+    .order("items_sold DESC, created_at DESC")
+    .limit(1)
+    .first
+  end
 end

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -49,4 +49,14 @@ class Merchant < ApplicationRecord
       .where(invoice_items: {status: 1})
       .order("invoices.created_at ASC")
   end
+
+  def most_popular_items
+    items
+      .joins(:invoice_items)
+      .select("items.*, SUM(invoice_items.quantity * invoice_items.unit_price) AS item_revenue")
+      .where("invoice_items.status = ?", 1)
+      .group("items.id")
+      .order("item_revenue DESC")
+      .limit(5)
+  end
 end

--- a/app/views/merchant_items/index.html.erb
+++ b/app/views/merchant_items/index.html.erb
@@ -5,7 +5,10 @@
 <h2>Popular items:</h2>
 <ol id="popular-items">
   <% @merchant.most_popular_items.each do |item| %>
-    <li><%= link_to "#{item.name}", url: "/merchants/#{@merchant.id}/items/#{item.id}" %> - Total revenue: <%= number_to_currency(item.item_revenue / 100) %></li>
+    <li><%= link_to "#{item.name}", url: "/merchants/#{@merchant.id}/items/#{item.id}" %>
+     - Total revenue: <%= number_to_currency(item.item_revenue / 100) %>
+     - Top selling date: <%= item.best_day.created_at.strftime("%m/%d/%Y") %>
+    </li>
   <% end %>
 </ol>
 

--- a/app/views/merchant_items/index.html.erb
+++ b/app/views/merchant_items/index.html.erb
@@ -2,6 +2,13 @@
 
 <p><%= link_to "Create an Item", "/merchants/#{@merchant.id}/items/new" %></p>
 
+<h2>Popular items:</h2>
+<ol id="popular-items">
+  <% @merchant.most_popular_items.each do |item| %>
+    <li><%= link_to "#{item.name}", url: "/merchants/#{@merchant.id}/items/#{item.id}" %> - Total revenue: <%= number_to_currency(item.item_revenue / 100) %></li>
+  <% end %>
+</ol>
+
 <h2>Enabled items:</h2>
 <ul id="status-enabled">
   <% @merchant.items.each do |item| %>

--- a/spec/features/merchant_items/index_spec.rb
+++ b/spec/features/merchant_items/index_spec.rb
@@ -153,10 +153,10 @@ RSpec.describe "MerchantItems Index", type: :feature do
       visit "/merchants/#{@merchant_1.id}/items"
 
       expect(page).to have_content(("#{@item_7.name} - Total revenue: $48.00 - Top selling date: 03/25/2012"))
-      expect(page).to have_content(("#{@item_2.name} - Total revenue: $48.00 - Top selling date: 03/26/2012"))
-      expect(page).to have_content(("#{@item_6.name} - Total revenue: $48.00 - Top selling date: 03/25/2012"))
-      expect(page).to have_content(("#{@item_3.name} - Total revenue: $48.00 - Top selling date: 03/26/2012"))
-      expect(page).to have_content(("#{@item_5.name} - Total revenue: $48.00 - Top selling date: 03/25/2012"))
+      expect(page).to have_content(("#{@item_2.name} - Total revenue: $40.00 - Top selling date: 03/26/2012"))
+      expect(page).to have_content(("#{@item_6.name} - Total revenue: $35.00 - Top selling date: 03/25/2012"))
+      expect(page).to have_content(("#{@item_3.name} - Total revenue: $30.00 - Top selling date: 03/26/2012"))
+      expect(page).to have_content(("#{@item_5.name} - Total revenue: $10.00 - Top selling date: 03/25/2012"))
     end
   end
 end

--- a/spec/features/merchant_items/index_spec.rb
+++ b/spec/features/merchant_items/index_spec.rb
@@ -86,5 +86,61 @@ RSpec.describe "MerchantItems Index", type: :feature do
 
       expect(page).to have_link("Create an Item", href: "/merchants/#{@merchant_1.id}/items/new")
     end
+
+    it "displays the top 5 most popular items, ranked by total revenue generated, and displays that revenue" do
+      merchant_1 = create(:merchant)
+      merchant_2 = create(:merchant)
+
+      customer_1 = create(:customer)
+      customer_2 = create(:customer)
+
+      invoice_1 = create(:invoice, customer: customer_1)
+      invoice_2 = create(:invoice, customer: customer_1)
+      invoice_3 = create(:invoice, customer: customer_2)
+      invoice_4 = create(:invoice, customer: customer_2)
+
+      item_1 = create(:item, merchant: merchant_1)
+      item_2 = create(:item, merchant: merchant_1) #
+      item_3 = create(:item, merchant: merchant_1) #
+      item_4 = create(:item, merchant: merchant_1)
+      item_5 = create(:item, merchant: merchant_1) #
+      item_6 = create(:item, merchant: merchant_1) #
+      item_7 = create(:item, merchant: merchant_1) #
+      item_8 = create(:item, merchant: merchant_2)
+      item_9 = create(:item, merchant: merchant_2)
+
+      invoice_item_1 = create(:invoice_item, item: item_1, invoice: invoice_1, quantity: 1, unit_price: 500)
+      invoice_item_2 = create(:invoice_item, item: item_2, invoice: invoice_1, quantity: 1, unit_price: 1000)
+      invoice_item_3 = create(:invoice_item, item: item_2, invoice: invoice_2, quantity: 3, unit_price: 1000)
+      invoice_item_4 = create(:invoice_item, item: item_3, invoice: invoice_2, quantity: 2, unit_price: 1500)
+      invoice_item_5 = create(:invoice_item, item: item_4, invoice: invoice_2, quantity: 10, unit_price: 40)
+      invoice_item_6 = create(:invoice_item, item: item_5, invoice: invoice_1, quantity: 1, unit_price: 1000)
+      invoice_item_7 = create(:invoice_item, item: item_6, invoice: invoice_1, quantity: 7, unit_price: 500)
+      invoice_item_8 = create(:invoice_item, item: item_7, invoice: invoice_1, quantity: 4, unit_price: 1200)
+      # item2 = 4000, item3 = 3000, item5 = 1000, item6 = 3500, item7 = 4800 || item1 = 500, item4 = 400
+      invoice_item_9 = create(:invoice_item, item: item_8, invoice: invoice_3, quantity: 10, unit_price: 1200)
+      invoice_item_10 = create(:invoice_item, item: item_9, invoice: invoice_4, quantity: 7, unit_price: 1000)
+
+      visit "/merchants/#{merchant_1.id}/items"
+
+      within("#popular-items") do
+        expect(page).to have_link(item_2.name)
+        expect(page).to have_link(item_3.name)
+        expect(page).to have_link(item_5.name)
+        expect(page).to have_link(item_6.name)
+        expect(page).to have_link(item_7.name)
+
+        expect(item_7.name).to appear_before(item_2.name)
+        expect(item_2.name).to appear_before(item_6.name)
+        expect(item_6.name).to appear_before(item_3.name)
+        expect(item_3.name).to appear_before(item_5.name)
+
+        expect(page).to have_content("#{item_7.name} - Total revenue: $48.00")
+        expect(page).to have_content("#{item_2.name} - Total revenue: $40.00")
+        expect(page).to have_content("#{item_6.name} - Total revenue: $35.00")
+        expect(page).to have_content("#{item_3.name} - Total revenue: $30.00")
+        expect(page).to have_content("#{item_5.name} - Total revenue: $10.00")
+      end
+    end
   end
 end

--- a/spec/features/merchant_items/index_spec.rb
+++ b/spec/features/merchant_items/index_spec.rb
@@ -1,21 +1,22 @@
 require 'rails_helper'
 
 RSpec.describe "MerchantItems Index", type: :feature do
-  before(:each) do
-    @merchant_1 = create(:merchant)
-    @merchant_2 = create(:merchant)
-    @item_1 = create(:item, merchant_id: @merchant_1.id)
-    @item_2 = create(:item, merchant_id: @merchant_1.id)
-    @item_3 = create(:item, merchant_id: @merchant_1.id, status: 0)
-    @item_4 = create(:item, merchant_id: @merchant_1.id, status: 0)
-    @item_5 = create(:item, merchant_id: @merchant_2.id)
-    @item_6 = create(:item, merchant_id: @merchant_2.id)
-    @item_7 = create(:item, merchant_id: @merchant_2.id)
-    @item_8 = create(:item, merchant_id: @merchant_2.id)
-    @item_9 = create(:item, merchant_id: @merchant_2.id)
-  end
-
+  
   describe "When I visit the merchantitems index page" do
+    before(:each) do
+      @merchant_1 = create(:merchant)
+      @merchant_2 = create(:merchant)
+      @item_1 = create(:item, merchant_id: @merchant_1.id)
+      @item_2 = create(:item, merchant_id: @merchant_1.id)
+      @item_3 = create(:item, merchant_id: @merchant_1.id, status: 0)
+      @item_4 = create(:item, merchant_id: @merchant_1.id, status: 0)
+      @item_5 = create(:item, merchant_id: @merchant_2.id)
+      @item_6 = create(:item, merchant_id: @merchant_2.id)
+      @item_7 = create(:item, merchant_id: @merchant_2.id)
+      @item_8 = create(:item, merchant_id: @merchant_2.id)
+      @item_9 = create(:item, merchant_id: @merchant_2.id)
+    end
+
     it "I see a list of all items associated with the current merchant, without items for other merchants" do
       visit "/merchants/#{@merchant_1.id}/items"
 
@@ -86,61 +87,76 @@ RSpec.describe "MerchantItems Index", type: :feature do
 
       expect(page).to have_link("Create an Item", href: "/merchants/#{@merchant_1.id}/items/new")
     end
+  end
+
+  context "popular items" do
+    before(:each) do
+      @merchant_1 = create(:merchant)
+      @merchant_2 = create(:merchant)
+  
+      @customer_1 = create(:customer)
+      @customer_2 = create(:customer)
+  
+      @invoice_1 = create(:invoice, customer: @customer_1, created_at: "2012-03-25 09:54:09 UTC")
+      @invoice_2 = create(:invoice, customer: @customer_1, created_at: "2012-03-26 09:54:09 UTC")
+      @invoice_3 = create(:invoice, customer: @customer_2)
+      @invoice_4 = create(:invoice, customer: @customer_2)
+  
+      @item_1 = create(:item, merchant: @merchant_1)
+      @item_2 = create(:item, merchant: @merchant_1) #
+      @item_3 = create(:item, merchant: @merchant_1) #
+      @item_4 = create(:item, merchant: @merchant_1)
+      @item_5 = create(:item, merchant: @merchant_1) #
+      @item_6 = create(:item, merchant: @merchant_1) #
+      @item_7 = create(:item, merchant: @merchant_1) #
+      @item_8 = create(:item, merchant: @merchant_2)
+      @item_9 = create(:item, merchant: @merchant_2)
+  
+      @invoice_item_1 = create(:invoice_item, item: @item_1, invoice: @invoice_1, quantity: 1, unit_price: 500)
+      @invoice_item_2 = create(:invoice_item, item: @item_2, invoice: @invoice_1, quantity: 1, unit_price: 1000)
+      @invoice_item_3 = create(:invoice_item, item: @item_2, invoice: @invoice_2, quantity: 3, unit_price: 1000)
+      @invoice_item_4 = create(:invoice_item, item: @item_3, invoice: @invoice_2, quantity: 2, unit_price: 1500)
+      @invoice_item_5 = create(:invoice_item, item: @item_4, invoice: @invoice_2, quantity: 10, unit_price: 40)
+      @invoice_item_6 = create(:invoice_item, item: @item_5, invoice: @invoice_1, quantity: 1, unit_price: 1000)
+      @invoice_item_7 = create(:invoice_item, item: @item_6, invoice: @invoice_1, quantity: 7, unit_price: 500)
+      @invoice_item_8 = create(:invoice_item, item: @item_7, invoice: @invoice_1, quantity: 4, unit_price: 1200)
+      # item2 = 4000, item3 = 3000, item5 = 1000, item6 = 3500, item7 = 4800 || item1 = 500, item4 = 400
+      @invoice_item_9 = create(:invoice_item, item: @item_8, invoice: @invoice_3, quantity: 10, unit_price: 1200)
+      @invoice_item_10 = create(:invoice_item, item: @item_9, invoice: @invoice_4, quantity: 7, unit_price: 1000)
+    end
 
     it "displays the top 5 most popular items, ranked by total revenue generated, and displays that revenue" do
-      merchant_1 = create(:merchant)
-      merchant_2 = create(:merchant)
 
-      customer_1 = create(:customer)
-      customer_2 = create(:customer)
-
-      invoice_1 = create(:invoice, customer: customer_1)
-      invoice_2 = create(:invoice, customer: customer_1)
-      invoice_3 = create(:invoice, customer: customer_2)
-      invoice_4 = create(:invoice, customer: customer_2)
-
-      item_1 = create(:item, merchant: merchant_1)
-      item_2 = create(:item, merchant: merchant_1) #
-      item_3 = create(:item, merchant: merchant_1) #
-      item_4 = create(:item, merchant: merchant_1)
-      item_5 = create(:item, merchant: merchant_1) #
-      item_6 = create(:item, merchant: merchant_1) #
-      item_7 = create(:item, merchant: merchant_1) #
-      item_8 = create(:item, merchant: merchant_2)
-      item_9 = create(:item, merchant: merchant_2)
-
-      invoice_item_1 = create(:invoice_item, item: item_1, invoice: invoice_1, quantity: 1, unit_price: 500)
-      invoice_item_2 = create(:invoice_item, item: item_2, invoice: invoice_1, quantity: 1, unit_price: 1000)
-      invoice_item_3 = create(:invoice_item, item: item_2, invoice: invoice_2, quantity: 3, unit_price: 1000)
-      invoice_item_4 = create(:invoice_item, item: item_3, invoice: invoice_2, quantity: 2, unit_price: 1500)
-      invoice_item_5 = create(:invoice_item, item: item_4, invoice: invoice_2, quantity: 10, unit_price: 40)
-      invoice_item_6 = create(:invoice_item, item: item_5, invoice: invoice_1, quantity: 1, unit_price: 1000)
-      invoice_item_7 = create(:invoice_item, item: item_6, invoice: invoice_1, quantity: 7, unit_price: 500)
-      invoice_item_8 = create(:invoice_item, item: item_7, invoice: invoice_1, quantity: 4, unit_price: 1200)
-      # item2 = 4000, item3 = 3000, item5 = 1000, item6 = 3500, item7 = 4800 || item1 = 500, item4 = 400
-      invoice_item_9 = create(:invoice_item, item: item_8, invoice: invoice_3, quantity: 10, unit_price: 1200)
-      invoice_item_10 = create(:invoice_item, item: item_9, invoice: invoice_4, quantity: 7, unit_price: 1000)
-
-      visit "/merchants/#{merchant_1.id}/items"
+      visit "/merchants/#{@merchant_1.id}/items"
 
       within("#popular-items") do
-        expect(page).to have_link(item_2.name)
-        expect(page).to have_link(item_3.name)
-        expect(page).to have_link(item_5.name)
-        expect(page).to have_link(item_6.name)
-        expect(page).to have_link(item_7.name)
+        expect(page).to have_link(@item_2.name)
+        expect(page).to have_link(@item_3.name)
+        expect(page).to have_link(@item_5.name)
+        expect(page).to have_link(@item_6.name)
+        expect(page).to have_link(@item_7.name)
 
-        expect(item_7.name).to appear_before(item_2.name)
-        expect(item_2.name).to appear_before(item_6.name)
-        expect(item_6.name).to appear_before(item_3.name)
-        expect(item_3.name).to appear_before(item_5.name)
+        expect(@item_7.name).to appear_before(@item_2.name)
+        expect(@item_2.name).to appear_before(@item_6.name)
+        expect(@item_6.name).to appear_before(@item_3.name)
+        expect(@item_3.name).to appear_before(@item_5.name)
 
-        expect(page).to have_content("#{item_7.name} - Total revenue: $48.00")
-        expect(page).to have_content("#{item_2.name} - Total revenue: $40.00")
-        expect(page).to have_content("#{item_6.name} - Total revenue: $35.00")
-        expect(page).to have_content("#{item_3.name} - Total revenue: $30.00")
-        expect(page).to have_content("#{item_5.name} - Total revenue: $10.00")
+        expect(page).to have_content("#{@item_7.name} - Total revenue: $48.00")
+        expect(page).to have_content("#{@item_2.name} - Total revenue: $40.00")
+        expect(page).to have_content("#{@item_6.name} - Total revenue: $35.00")
+        expect(page).to have_content("#{@item_3.name} - Total revenue: $30.00")
+        expect(page).to have_content("#{@item_5.name} - Total revenue: $10.00")
       end
+    end
+
+    it "displays the best day for each of the most popular items" do
+      visit "/merchants/#{@merchant_1.id}/items"
+
+      expect(page).to have_content(("#{@item_7.name} - Total revenue: $48.00 - Top selling date: 03/25/2012"))
+      expect(page).to have_content(("#{@item_2.name} - Total revenue: $48.00 - Top selling date: 03/26/2012"))
+      expect(page).to have_content(("#{@item_6.name} - Total revenue: $48.00 - Top selling date: 03/25/2012"))
+      expect(page).to have_content(("#{@item_3.name} - Total revenue: $48.00 - Top selling date: 03/26/2012"))
+      expect(page).to have_content(("#{@item_5.name} - Total revenue: $48.00 - Top selling date: 03/25/2012"))
     end
   end
 end

--- a/spec/features/merchant_items/index_spec.rb
+++ b/spec/features/merchant_items/index_spec.rb
@@ -112,17 +112,17 @@ RSpec.describe "MerchantItems Index", type: :feature do
       @item_8 = create(:item, merchant: @merchant_2)
       @item_9 = create(:item, merchant: @merchant_2)
   
-      @invoice_item_1 = create(:invoice_item, item: @item_1, invoice: @invoice_1, quantity: 1, unit_price: 500)
-      @invoice_item_2 = create(:invoice_item, item: @item_2, invoice: @invoice_1, quantity: 1, unit_price: 1000)
-      @invoice_item_3 = create(:invoice_item, item: @item_2, invoice: @invoice_2, quantity: 3, unit_price: 1000)
-      @invoice_item_4 = create(:invoice_item, item: @item_3, invoice: @invoice_2, quantity: 2, unit_price: 1500)
-      @invoice_item_5 = create(:invoice_item, item: @item_4, invoice: @invoice_2, quantity: 10, unit_price: 40)
-      @invoice_item_6 = create(:invoice_item, item: @item_5, invoice: @invoice_1, quantity: 1, unit_price: 1000)
-      @invoice_item_7 = create(:invoice_item, item: @item_6, invoice: @invoice_1, quantity: 7, unit_price: 500)
-      @invoice_item_8 = create(:invoice_item, item: @item_7, invoice: @invoice_1, quantity: 4, unit_price: 1200)
+      @invoice_item_1 = create(:invoice_item, item: @item_1, invoice: @invoice_1, quantity: 1, unit_price: 500, status: 1)
+      @invoice_item_2 = create(:invoice_item, item: @item_2, invoice: @invoice_1, quantity: 1, unit_price: 1000, status: 1)
+      @invoice_item_3 = create(:invoice_item, item: @item_2, invoice: @invoice_2, quantity: 3, unit_price: 1000, status: 1)
+      @invoice_item_4 = create(:invoice_item, item: @item_3, invoice: @invoice_2, quantity: 2, unit_price: 1500, status: 1)
+      @invoice_item_5 = create(:invoice_item, item: @item_4, invoice: @invoice_2, quantity: 10, unit_price: 40, status: 1)
+      @invoice_item_6 = create(:invoice_item, item: @item_5, invoice: @invoice_1, quantity: 1, unit_price: 1000, status: 1)
+      @invoice_item_7 = create(:invoice_item, item: @item_6, invoice: @invoice_1, quantity: 7, unit_price: 500, status: 1)
+      @invoice_item_8 = create(:invoice_item, item: @item_7, invoice: @invoice_1, quantity: 4, unit_price: 1200, status: 1)
       # item2 = 4000, item3 = 3000, item5 = 1000, item6 = 3500, item7 = 4800 || item1 = 500, item4 = 400
-      @invoice_item_9 = create(:invoice_item, item: @item_8, invoice: @invoice_3, quantity: 10, unit_price: 1200)
-      @invoice_item_10 = create(:invoice_item, item: @item_9, invoice: @invoice_4, quantity: 7, unit_price: 1000)
+      @invoice_item_9 = create(:invoice_item, item: @item_8, invoice: @invoice_3, quantity: 10, unit_price: 1200, status: 1)
+      @invoice_item_10 = create(:invoice_item, item: @item_9, invoice: @invoice_4, quantity: 7, unit_price: 1000, status: 1)
     end
 
     it "displays the top 5 most popular items, ranked by total revenue generated, and displays that revenue" do

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -46,11 +46,11 @@ RSpec.describe Item, type: :model do
         @item_1 = create(:item, merchant: @merchant_1)
         @item_2 = create(:item, merchant: @merchant_1)
     
-        @invoice_item_1 = create(:invoice_item, item: @item_1, invoice: @invoice_1, quantity: 1, unit_price: 500)
-        @invoice_item_4 = create(:invoice_item, item: @item_1, invoice: @invoice_3, quantity: 1, unit_price: 500)
-        @invoice_item_5 = create(:invoice_item, item: @item_1, invoice: @invoice_2, quantity: 1, unit_price: 500)
-        @invoice_item_2 = create(:invoice_item, item: @item_2, invoice: @invoice_1, quantity: 1, unit_price: 1000)
-        @invoice_item_3 = create(:invoice_item, item: @item_2, invoice: @invoice_2, quantity: 3, unit_price: 1000)
+        @invoice_item_1 = create(:invoice_item, item: @item_1, invoice: @invoice_1, quantity: 1, unit_price: 500, status: 1)
+        @invoice_item_4 = create(:invoice_item, item: @item_1, invoice: @invoice_3, quantity: 1, unit_price: 500, status: 1)
+        @invoice_item_5 = create(:invoice_item, item: @item_1, invoice: @invoice_2, quantity: 1, unit_price: 500, status: 1)
+        @invoice_item_2 = create(:invoice_item, item: @item_2, invoice: @invoice_1, quantity: 1, unit_price: 1000, status: 1)
+        @invoice_item_3 = create(:invoice_item, item: @item_2, invoice: @invoice_2, quantity: 3, unit_price: 1000, status: 1)
       end
 
       it "returns the day that the item sold the most" do

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -12,21 +12,23 @@ RSpec.describe Item, type: :model do
     it { should validate_presence_of(:description) }
   end
 
-  describe "unit_price_formatted" do
-    it "can convert unit_price to dollars" do
-      item = Item.new(unit_price: 12345)
-      expect(item.unit_price_formatted).to eq(123.45)
+  describe "instance methods" do
+    describe "unit_price_formatted" do
+      it "can convert unit_price to dollars" do
+        item = Item.new(unit_price: 12345)
+        expect(item.unit_price_formatted).to eq(123.45)
+      end
+  
+      it "can handle zero" do
+        item = Item.new(unit_price: 0)
+        expect(item.unit_price_formatted).to eq(0)
+      end
     end
-
-    it "can handle zero" do
-      item = Item.new(unit_price: 0)
-      expect(item.unit_price_formatted).to eq(0)
-    end
-  end
-
-  describe "ready_to_ship" do
-    it "can display items with a status of 'packaged'" do
-      
+  
+    describe "ready_to_ship" do
+      it "can display items with a status of 'packaged'" do
+        
+      end
     end
   end
 end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe Item, type: :model do
   describe "relationships" do
     it { should belong_to :merchant }
     it { should have_many :invoice_items }
+    it { should have_many(:invoices).through(:invoice_items) }
   end
 
   describe "validations" do
@@ -28,6 +29,36 @@ RSpec.describe Item, type: :model do
     describe "ready_to_ship" do
       it "can display items with a status of 'packaged'" do
         
+      end
+    end
+
+    describe "#best_day" do
+      before(:each) do
+        @merchant_1 = create(:merchant)
+    
+        @customer_1 = create(:customer)
+    
+        @invoice_1 = create(:invoice, customer: @customer_1, created_at: "2012-03-25 09:54:09 UTC")
+        @invoice_2 = create(:invoice, customer: @customer_1, created_at: "2012-03-26 09:54:09 UTC")
+        @invoice_3 = create(:invoice, customer: @customer_1, created_at: "2012-03-25 10:54:09 UTC")
+
+    
+        @item_1 = create(:item, merchant: @merchant_1)
+        @item_2 = create(:item, merchant: @merchant_1)
+    
+        @invoice_item_1 = create(:invoice_item, item: @item_1, invoice: @invoice_1, quantity: 1, unit_price: 500)
+        @invoice_item_4 = create(:invoice_item, item: @item_1, invoice: @invoice_3, quantity: 1, unit_price: 500)
+        @invoice_item_5 = create(:invoice_item, item: @item_1, invoice: @invoice_2, quantity: 1, unit_price: 500)
+        @invoice_item_2 = create(:invoice_item, item: @item_2, invoice: @invoice_1, quantity: 1, unit_price: 1000)
+        @invoice_item_3 = create(:invoice_item, item: @item_2, invoice: @invoice_2, quantity: 3, unit_price: 1000)
+      end
+
+      it "returns the day that the item sold the most" do
+        expect(@item_2.best_day.created_at.strftime("%m/%d/%Y")).to eq("03/26/2012")
+      end
+
+      it "can handle multiple invoices with a mix of similar and different days" do
+        expect(@item_1.best_day.created_at.strftime("%m/%d/%Y")).to eq("03/25/2012")
       end
     end
   end

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -84,7 +84,6 @@ RSpec.describe Merchant, type: :model do
         # item2 = 4000, item3 = 3000, item5 = 1000, item6 = 3500, item7 = 4800 || item1 = 500, item4 = 400
         invoice_item_9 = create(:invoice_item, item: item_8, invoice: invoice_3, quantity: 10, unit_price: 1200)
         invoice_item_10 = create(:invoice_item, item: item_9, invoice: invoice_4, quantity: 7, unit_price: 1000)
-
         expect(merchant_1.most_popular_items).to eq([item_7, item_2, item_6, item_3, item_5])
       end
     end

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -73,17 +73,17 @@ RSpec.describe Merchant, type: :model do
         item_8 = create(:item, merchant: merchant_2)
         item_9 = create(:item, merchant: merchant_2)
 
-        invoice_item_1 = create(:invoice_item, item: item_1, invoice: invoice_1, quantity: 1, unit_price: 500)
-        invoice_item_2 = create(:invoice_item, item: item_2, invoice: invoice_1, quantity: 1, unit_price: 1000)
-        invoice_item_3 = create(:invoice_item, item: item_2, invoice: invoice_2, quantity: 3, unit_price: 1000)
-        invoice_item_4 = create(:invoice_item, item: item_3, invoice: invoice_2, quantity: 2, unit_price: 1500)
-        invoice_item_5 = create(:invoice_item, item: item_4, invoice: invoice_2, quantity: 10, unit_price: 40)
-        invoice_item_6 = create(:invoice_item, item: item_5, invoice: invoice_1, quantity: 1, unit_price: 1000)
-        invoice_item_7 = create(:invoice_item, item: item_6, invoice: invoice_1, quantity: 7, unit_price: 500)
-        invoice_item_8 = create(:invoice_item, item: item_7, invoice: invoice_1, quantity: 4, unit_price: 1200)
+        invoice_item_1 = create(:invoice_item, item: item_1, invoice: invoice_1, quantity: 1, unit_price: 500, status: 1)
+        invoice_item_2 = create(:invoice_item, item: item_2, invoice: invoice_1, quantity: 1, unit_price: 1000, status: 1)
+        invoice_item_3 = create(:invoice_item, item: item_2, invoice: invoice_2, quantity: 3, unit_price: 1000, status: 1)
+        invoice_item_4 = create(:invoice_item, item: item_3, invoice: invoice_2, quantity: 2, unit_price: 1500, status: 1)
+        invoice_item_5 = create(:invoice_item, item: item_4, invoice: invoice_2, quantity: 10, unit_price: 40, status: 1)
+        invoice_item_6 = create(:invoice_item, item: item_5, invoice: invoice_1, quantity: 1, unit_price: 1000, status: 1)
+        invoice_item_7 = create(:invoice_item, item: item_6, invoice: invoice_1, quantity: 7, unit_price: 500, status: 1)
+        invoice_item_8 = create(:invoice_item, item: item_7, invoice: invoice_1, quantity: 4, unit_price: 1200, status: 1)
         # item2 = 4000, item3 = 3000, item5 = 1000, item6 = 3500, item7 = 4800 || item1 = 500, item4 = 400
-        invoice_item_9 = create(:invoice_item, item: item_8, invoice: invoice_3, quantity: 10, unit_price: 1200)
-        invoice_item_10 = create(:invoice_item, item: item_9, invoice: invoice_4, quantity: 7, unit_price: 1000)
+        invoice_item_9 = create(:invoice_item, item: item_8, invoice: invoice_3, quantity: 10, unit_price: 1200, status: 1)
+        invoice_item_10 = create(:invoice_item, item: item_9, invoice: invoice_4, quantity: 7, unit_price: 1000, status: 1)
         expect(merchant_1.most_popular_items).to eq([item_7, item_2, item_6, item_3, item_5])
       end
     end

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -17,109 +17,150 @@ RSpec.describe Merchant, type: :model do
         expect(merchant.disabled).to eq(true)
       end
     end
-  end
 
-  describe "top_revenue" do
-    it "returns the top 5 merchants by revenue" do  
-      merchant_1 = create(:merchant)
-      merchant_2 = create(:merchant)
-      merchant_3 = create(:merchant)
-      merchant_4 = create(:merchant)
-      merchant_5 = create(:merchant)
-      merchant_6 = create(:merchant)
-      merchant_7 = create(:merchant)
-      merchant_8 = create(:merchant)
-      merchant_9 = create(:merchant)
-      merchant_10 = create(:merchant)
+    describe "Top date" do
+      it "returns the date with the most sales for a merchant" do
+        merchant_1 = create(:merchant)
+        merchant_2 = create(:merchant)
+        merchant_3 = create(:merchant)
+  
+        customer_1 = create(:customer)
+        customer_2 = create(:customer)
+        customer_3 = create(:customer)
+  
+        item_1 = create(:item, merchant: merchant_1)
+        item_2 = create(:item, merchant: merchant_2)
+        item_3 = create(:item, merchant: merchant_3)
+  
+        invoice_1 = create(:invoice, customer: customer_1, created_at: "2021-04-01 14:54:05 UTC")
+        invoice_2 = create(:invoice, customer: customer_2, created_at: "2021-04-06 11:33:00 UTC")
+        invoice_3 = create(:invoice, customer: customer_3, created_at: "2021-04-10 20:00:22 UTC")
+  
+        invoice_item_1 = create(:invoice_item, item: item_1, invoice: invoice_1, quantity: 1, unit_price: 1000)
+        invoice_item_2 = create(:invoice_item, item: item_2, invoice: invoice_2, quantity: 1, unit_price: 2000)
+        invoice_item_3 = create(:invoice_item, item: item_3, invoice: invoice_3, quantity: 1, unit_price: 3000)
+  
+        transaction_1 = create(:transaction, invoice: invoice_1, result: 1)
+        transaction_2 = create(:transaction, invoice: invoice_2, result: 1)
+        transaction_3 = create(:transaction, invoice: invoice_3, result: 1)
+  
+        expect(merchant_1.top_date).to eq(Date.new(2021, 4, 1))
+        expect(merchant_2.top_date).to eq(Date.new(2021, 4, 6))
+        expect(merchant_3.top_date).to eq(Date.new(2021, 4, 10))
+      end
+    end
 
-      customer_1 = create(:customer)
-      customer_2 = create(:customer)
-      customer_3 = create(:customer)
-      customer_4 = create(:customer)
-      customer_5 = create(:customer)
-      customer_6 = create(:customer)
-      customer_7 = create(:customer)
-      customer_8 = create(:customer)
-      customer_9 = create(:customer)
-      customer_10 = create(:customer)
+    describe "#most_popular_items" do
+      it "returns the top 5 items by revenue for a merchant" do
+        merchant_1 = create(:merchant)
+        merchant_2 = create(:merchant)
 
-      item_1 = create(:item, merchant: merchant_1)
-      item_2 = create(:item, merchant: merchant_2)
-      item_3 = create(:item, merchant: merchant_3)
-      item_4 = create(:item, merchant: merchant_4)
-      item_5 = create(:item, merchant: merchant_5)
-      item_6 = create(:item, merchant: merchant_6)
-      item_7 = create(:item, merchant: merchant_7)
-      item_8 = create(:item, merchant: merchant_8)
-      item_9 = create(:item, merchant: merchant_9)
-      item_10 = create(:item, merchant: merchant_10)
+        customer_1 = create(:customer)
+        customer_2 = create(:customer)
 
-      invoice_1 = create(:invoice, customer: customer_1)
-      invoice_2 = create(:invoice, customer: customer_2)
-      invoice_3 = create(:invoice, customer: customer_3)
-      invoice_4 = create(:invoice, customer: customer_4)
-      invoice_5 = create(:invoice, customer: customer_5)
-      invoice_6 = create(:invoice, customer: customer_6)
-      invoice_7 = create(:invoice, customer: customer_7)
-      invoice_8 = create(:invoice, customer: customer_8)
-      invoice_9 = create(:invoice, customer: customer_9)
-      invoice_10 = create(:invoice, customer: customer_10)
+        invoice_1 = create(:invoice, customer: customer_1)
+        invoice_2 = create(:invoice, customer: customer_1)
+        invoice_3 = create(:invoice, customer: customer_2)
+        invoice_4 = create(:invoice, customer: customer_2)
 
-      invoice_item_1 = create(:invoice_item, item: item_1, invoice: invoice_1, quantity: 1, unit_price: 1000)
-      invoice_item_2 = create(:invoice_item, item: item_2, invoice: invoice_2, quantity: 1, unit_price: 2000)
-      invoice_item_3 = create(:invoice_item, item: item_3, invoice: invoice_3, quantity: 1, unit_price: 3000)
-      invoice_item_4 = create(:invoice_item, item: item_4, invoice: invoice_4, quantity: 1, unit_price: 4000)
-      invoice_item_5 = create(:invoice_item, item: item_5, invoice: invoice_5, quantity: 1, unit_price: 5000)
-      invoice_item_6 = create(:invoice_item, item: item_6, invoice: invoice_6, quantity: 1, unit_price: 6000)
-      invoice_item_7 = create(:invoice_item, item: item_7, invoice: invoice_7, quantity: 1, unit_price: 7000)
-      invoice_item_8 = create(:invoice_item, item: item_8, invoice: invoice_8, quantity: 1, unit_price: 8000)
-      invoice_item_9 = create(:invoice_item, item: item_9, invoice: invoice_9, quantity: 1, unit_price: 9000)
-      invoice_item_10 = create(:invoice_item, item: item_10, invoice: invoice_10, quantity: 1, unit_price: 10000)
+        item_1 = create(:item, merchant: merchant_1)
+        item_2 = create(:item, merchant: merchant_1) #
+        item_3 = create(:item, merchant: merchant_1) #
+        item_4 = create(:item, merchant: merchant_1)
+        item_5 = create(:item, merchant: merchant_1) #
+        item_6 = create(:item, merchant: merchant_1) #
+        item_7 = create(:item, merchant: merchant_1) #
+        item_8 = create(:item, merchant: merchant_2)
+        item_9 = create(:item, merchant: merchant_2)
 
-      transaction_1 = create(:transaction, invoice: invoice_1, result: 1)
-      transaction_2 = create(:transaction, invoice: invoice_2, result: 1)
-      transaction_3 = create(:transaction, invoice: invoice_3, result: 1)
-      transaction_4 = create(:transaction, invoice: invoice_4, result: 1)
-      transaction_5 = create(:transaction, invoice: invoice_5, result: 1)
-      transaction_6 = create(:transaction, invoice: invoice_6, result: 1)
-      transaction_7 = create(:transaction, invoice: invoice_7, result: 1)
-      transaction_8 = create(:transaction, invoice: invoice_8, result: 1)
-      transaction_9 = create(:transaction, invoice: invoice_9, result: 1)
-      transaction_10 = create(:transaction, invoice: invoice_10, result: 1)
+        invoice_item_1 = create(:invoice_item, item: item_1, invoice: invoice_1, quantity: 1, unit_price: 500)
+        invoice_item_2 = create(:invoice_item, item: item_2, invoice: invoice_1, quantity: 1, unit_price: 1000)
+        invoice_item_3 = create(:invoice_item, item: item_2, invoice: invoice_2, quantity: 3, unit_price: 1000)
+        invoice_item_4 = create(:invoice_item, item: item_3, invoice: invoice_2, quantity: 2, unit_price: 1500)
+        invoice_item_5 = create(:invoice_item, item: item_4, invoice: invoice_2, quantity: 10, unit_price: 40)
+        invoice_item_6 = create(:invoice_item, item: item_5, invoice: invoice_1, quantity: 1, unit_price: 1000)
+        invoice_item_7 = create(:invoice_item, item: item_6, invoice: invoice_1, quantity: 7, unit_price: 500)
+        invoice_item_8 = create(:invoice_item, item: item_7, invoice: invoice_1, quantity: 4, unit_price: 1200)
+        # item2 = 4000, item3 = 3000, item5 = 1000, item6 = 3500, item7 = 4800 || item1 = 500, item4 = 400
+        invoice_item_9 = create(:invoice_item, item: item_8, invoice: invoice_3, quantity: 10, unit_price: 1200)
+        invoice_item_10 = create(:invoice_item, item: item_9, invoice: invoice_4, quantity: 7, unit_price: 1000)
 
-      expect(Merchant.top_revenue).to eq([merchant_10, merchant_9, merchant_8, merchant_7, merchant_6])
+        expect(merchant_1.most_popular_items).to eq([item_7, item_2, item_6, item_3, item_5])
+      end
     end
   end
 
-  describe "Top date" do
-    it "returns the date with the most sales for a merchant" do
-      merchant_1 = create(:merchant)
-      merchant_2 = create(:merchant)
-      merchant_3 = create(:merchant)
-
-      customer_1 = create(:customer)
-      customer_2 = create(:customer)
-      customer_3 = create(:customer)
-
-      item_1 = create(:item, merchant: merchant_1)
-      item_2 = create(:item, merchant: merchant_2)
-      item_3 = create(:item, merchant: merchant_3)
-
-      invoice_1 = create(:invoice, customer: customer_1, created_at: "2021-04-01 14:54:05 UTC")
-      invoice_2 = create(:invoice, customer: customer_2, created_at: "2021-04-06 11:33:00 UTC")
-      invoice_3 = create(:invoice, customer: customer_3, created_at: "2021-04-10 20:00:22 UTC")
-
-      invoice_item_1 = create(:invoice_item, item: item_1, invoice: invoice_1, quantity: 1, unit_price: 1000)
-      invoice_item_2 = create(:invoice_item, item: item_2, invoice: invoice_2, quantity: 1, unit_price: 2000)
-      invoice_item_3 = create(:invoice_item, item: item_3, invoice: invoice_3, quantity: 1, unit_price: 3000)
-
-      transaction_1 = create(:transaction, invoice: invoice_1, result: 1)
-      transaction_2 = create(:transaction, invoice: invoice_2, result: 1)
-      transaction_3 = create(:transaction, invoice: invoice_3, result: 1)
-
-      expect(merchant_1.top_date).to eq(Date.new(2021, 4, 1))
-      expect(merchant_2.top_date).to eq(Date.new(2021, 4, 6))
-      expect(merchant_3.top_date).to eq(Date.new(2021, 4, 10))
+  describe "class methods" do
+    describe "top_revenue" do
+      it "returns the top 5 merchants by revenue" do  
+        merchant_1 = create(:merchant)
+        merchant_2 = create(:merchant)
+        merchant_3 = create(:merchant)
+        merchant_4 = create(:merchant)
+        merchant_5 = create(:merchant)
+        merchant_6 = create(:merchant)
+        merchant_7 = create(:merchant)
+        merchant_8 = create(:merchant)
+        merchant_9 = create(:merchant)
+        merchant_10 = create(:merchant)
+  
+        customer_1 = create(:customer)
+        customer_2 = create(:customer)
+        customer_3 = create(:customer)
+        customer_4 = create(:customer)
+        customer_5 = create(:customer)
+        customer_6 = create(:customer)
+        customer_7 = create(:customer)
+        customer_8 = create(:customer)
+        customer_9 = create(:customer)
+        customer_10 = create(:customer)
+  
+        item_1 = create(:item, merchant: merchant_1)
+        item_2 = create(:item, merchant: merchant_2)
+        item_3 = create(:item, merchant: merchant_3)
+        item_4 = create(:item, merchant: merchant_4)
+        item_5 = create(:item, merchant: merchant_5)
+        item_6 = create(:item, merchant: merchant_6)
+        item_7 = create(:item, merchant: merchant_7)
+        item_8 = create(:item, merchant: merchant_8)
+        item_9 = create(:item, merchant: merchant_9)
+        item_10 = create(:item, merchant: merchant_10)
+  
+        invoice_1 = create(:invoice, customer: customer_1)
+        invoice_2 = create(:invoice, customer: customer_2)
+        invoice_3 = create(:invoice, customer: customer_3)
+        invoice_4 = create(:invoice, customer: customer_4)
+        invoice_5 = create(:invoice, customer: customer_5)
+        invoice_6 = create(:invoice, customer: customer_6)
+        invoice_7 = create(:invoice, customer: customer_7)
+        invoice_8 = create(:invoice, customer: customer_8)
+        invoice_9 = create(:invoice, customer: customer_9)
+        invoice_10 = create(:invoice, customer: customer_10)
+  
+        invoice_item_1 = create(:invoice_item, item: item_1, invoice: invoice_1, quantity: 1, unit_price: 1000)
+        invoice_item_2 = create(:invoice_item, item: item_2, invoice: invoice_2, quantity: 1, unit_price: 2000)
+        invoice_item_3 = create(:invoice_item, item: item_3, invoice: invoice_3, quantity: 1, unit_price: 3000)
+        invoice_item_4 = create(:invoice_item, item: item_4, invoice: invoice_4, quantity: 1, unit_price: 4000)
+        invoice_item_5 = create(:invoice_item, item: item_5, invoice: invoice_5, quantity: 1, unit_price: 5000)
+        invoice_item_6 = create(:invoice_item, item: item_6, invoice: invoice_6, quantity: 1, unit_price: 6000)
+        invoice_item_7 = create(:invoice_item, item: item_7, invoice: invoice_7, quantity: 1, unit_price: 7000)
+        invoice_item_8 = create(:invoice_item, item: item_8, invoice: invoice_8, quantity: 1, unit_price: 8000)
+        invoice_item_9 = create(:invoice_item, item: item_9, invoice: invoice_9, quantity: 1, unit_price: 9000)
+        invoice_item_10 = create(:invoice_item, item: item_10, invoice: invoice_10, quantity: 1, unit_price: 10000)
+  
+        transaction_1 = create(:transaction, invoice: invoice_1, result: 1)
+        transaction_2 = create(:transaction, invoice: invoice_2, result: 1)
+        transaction_3 = create(:transaction, invoice: invoice_3, result: 1)
+        transaction_4 = create(:transaction, invoice: invoice_4, result: 1)
+        transaction_5 = create(:transaction, invoice: invoice_5, result: 1)
+        transaction_6 = create(:transaction, invoice: invoice_6, result: 1)
+        transaction_7 = create(:transaction, invoice: invoice_7, result: 1)
+        transaction_8 = create(:transaction, invoice: invoice_8, result: 1)
+        transaction_9 = create(:transaction, invoice: invoice_9, result: 1)
+        transaction_10 = create(:transaction, invoice: invoice_10, result: 1)
+  
+        expect(Merchant.top_revenue).to eq([merchant_10, merchant_9, merchant_8, merchant_7, merchant_6])
+      end
     end
   end
 end


### PR DESCRIPTION
Database/Migrations:

Routes:

Models:
- Add #best_day instance method to Item model
- add #most_popular_items instance method to Merchant model

Controllers:

Views:
- Update merchant_items index page to include most popular items, each of their total revenue, and their best selling days

Testing:
- Model testing for item and merchant models
- Feature testing for merchant_items index

Features:
- Adds a couple of model methods for finding top selling items, as well as each of those items best days
- Updates the merchant_items index to display the results of the above methods

Considerations(Extra notes, refactors, etc.):
- Nothing more than the queries were rougher than I expected
- The #best_day method uses date-type casting to account for invoices that occurred on the same day at different times. Basically, because the created_at colum is a DateTime, I casted down to just Date to deliberately ignore time. I'll be honest and say I'm not confident that was necessary to account for, but I do think it's *more correct* to account for.